### PR TITLE
add installation steps for macOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,26 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 # With encoder and underglow rgb
 
+## macOS
+
+- Install [Homebrew](https://brew.sh/)
+- Install `qmk` with Homebrew
+
+```sh
+brew install qmk/qmk/qmk
+```
+- Clone `qmk_firmware` with submodules
+
+```sh
+git clone --recurse-submodules git@github.com:qmk/qmk_firmware.git
+```
+
+> Not cloning manually might result in error
+
+- Run `qmk setup` to install the necessary dependencies
+
+Now simply flash your profile with `qmk flash -kb lily58 -km <profile-name>`
+
 ## Windows
 
 Install and setup QMK MSYS on your computer. After opening up the QMK MSYS


### PR DESCRIPTION
## Description

Installation of `qmk` in macOS is error prone via the `qmk setup` command. Submodules get cloned without files.

Cloning the `qmk_firmware` repo before running `qmk setup` can prevent this issue.

## Changes

Added installation steps for macOS